### PR TITLE
ci: deploy to Cloudflare Pages via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=marseille-tarot


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` to automate deployments on every push to `master`
- Builds with `npm ci && npm run build`, then deploys `dist/` using Wrangler (already configured in `wrangler.toml`)

## Setup required
Add these two secrets to the repository settings before the workflow runs:
- `CLOUDFLARE_API_TOKEN` — API token with Cloudflare Pages edit permissions
- `CLOUDFLARE_ACCOUNT_ID` — your Cloudflare account ID