### PR TITLE
feat: make revealed cards readable on click

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -379,9 +379,9 @@ img { display: block; max-width: 100%; }
   white-space: nowrap;
 }
 
-/* Hover glow on clickable cards */
-.card-container[role='button']:hover .card-inner,
-.card-container[role='button']:focus .card-inner {
+/* Hover glow on clickable cards — only unflipped, to avoid flattening the preserve-3d context on revealed cards */
+.card-container[role='button']:hover .card-inner:not(.is-flipped),
+.card-container[role='button']:focus .card-inner:not(.is-flipped) {
   filter: drop-shadow(0 0 12px rgba(201,168,76,0.4));
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -932,6 +932,88 @@ img { display: block; max-width: 100%; }
   line-height: 1.7;
 }
 
+/* ─── Card meaning modal ─────────────────────────────────────── */
+
+.card-meaning-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 7, 26, 0.88);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 500;
+  padding: var(--space-lg);
+  backdrop-filter: blur(8px);
+}
+
+.card-meaning-modal {
+  position: relative;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-gold);
+  border-radius: 16px;
+  padding: var(--space-2xl);
+  max-width: 480px;
+  width: 100%;
+  animation: fadeUp var(--anim-fast) ease;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.6), var(--shadow-glow);
+}
+
+.card-meaning-close {
+  position: absolute;
+  top: var(--space-md);
+  right: var(--space-md);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color var(--anim-fast), color var(--anim-fast);
+}
+
+.card-meaning-close:hover {
+  border-color: var(--color-accent-gold);
+  color: var(--color-accent-gold);
+}
+
+.card-meaning-pos {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-sm);
+}
+
+.card-meaning-pos-desc {
+  font-size: 0.82rem;
+  color: var(--color-text-secondary);
+  font-style: italic;
+  line-height: 1.6;
+  margin-bottom: var(--space-md);
+  padding-bottom: var(--space-md);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.card-meaning-name {
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  color: var(--color-accent-gold);
+  margin-bottom: var(--space-xs);
+}
+
+.card-meaning-text {
+  font-size: 0.92rem;
+  color: var(--color-text-primary);
+  line-height: 1.75;
+  margin-top: var(--space-md);
+}
+
 /* ─── Animations ─────────────────────────────────────────────── */
 
 @keyframes shimmer {

--- a/src/i18n/ui.js
+++ b/src/i18n/ui.js
@@ -65,6 +65,7 @@ export const UI = {
       summaryBtn: '✦ Resumen de la Lectura',
       summaryTitle: 'Resumen de tu Lectura',
       summaryBack: '← Volver a la Tirada',
+      closeModal: 'Cerrar',
     },
     journal: {
       title: 'Diario', today: 'Hoy', pastReadings: 'Lecturas Pasadas',
@@ -150,6 +151,7 @@ export const UI = {
       summaryBtn: '✦ Reading Summary',
       summaryTitle: 'Your Reading Summary',
       summaryBack: '← Back to Spread',
+      closeModal: 'Close',
     },
     journal: {
       title: 'Daily Journal', today: 'Today', pastReadings: 'Past Readings',
@@ -235,6 +237,7 @@ export const UI = {
       summaryBtn: '✦ Résumé de la Lecture',
       summaryTitle: 'Résumé de ta Lecture',
       summaryBack: '← Retour au Tirage',
+      closeModal: 'Fermer',
     },
     journal: {
       title: 'Journal', today: "Aujourd'hui", pastReadings: 'Lectures Passées',

--- a/src/pages/Spreads.jsx
+++ b/src/pages/Spreads.jsx
@@ -21,6 +21,7 @@ export default function Spreads() {
   const [notebookEntries, setNotebookEntries] = useState([]);
   const [focusedSlotIndex, setFocusedSlotIndex] = useState(null);
   const [showSummary,     setShowSummary]     = useState(false);
+  const [cardModal,       setCardModal]       = useState(null);
 
   function handleSpreadSelect(spreadId) {
     setPendingSpread(SPREADS[spreadId]);
@@ -37,6 +38,7 @@ export default function Spreads() {
     setNotebookEntries([]);
     setFocusedSlotIndex(null);
     setShowSummary(false);
+    setCardModal(null);
     setPhase('reading');
   }
 
@@ -44,6 +46,9 @@ export default function Spreads() {
     const entry = drawnCards[index];
     if (!entry) return;
     if (entry.isFlipped) {
+      const pos = selectedSpread.positions[index];
+      const notebookEntry = notebookEntries.find(e => e.positionIndex === index);
+      setCardModal(notebookEntry ?? { card: entry.card, isReversed: entry.isReversed, pos, positionIndex: index });
       setFocusedSlotIndex(index);
       return;
     }
@@ -65,6 +70,7 @@ export default function Spreads() {
     setIntention('');
     setPendingSpread(null);
     setShowSummary(false);
+    setCardModal(null);
   }
 
   // ── Selector ─────────────────────────────────────────────────────────────────
@@ -244,6 +250,35 @@ export default function Spreads() {
           />
         </div>
       </div>
+
+      {cardModal && (
+        <div
+          className="card-meaning-overlay"
+          onClick={() => setCardModal(null)}
+          role="dialog"
+          aria-modal="true"
+          aria-label={getCardName(cardModal.card, lang)}
+        >
+          <div className="card-meaning-modal" onClick={e => e.stopPropagation()}>
+            <button
+              className="card-meaning-close"
+              onClick={() => setCardModal(null)}
+              aria-label={ui.closeModal}
+            >
+              ×
+            </button>
+            <div className="card-meaning-pos">{getPositionLabel(cardModal.pos, lang)}</div>
+            {getPositionDescription(cardModal.pos, lang) && (
+              <p className="card-meaning-pos-desc">{getPositionDescription(cardModal.pos, lang)}</p>
+            )}
+            <h3 className="card-meaning-name">{getCardName(cardModal.card, lang)}</h3>
+            <span className={`orientation-badge ${cardModal.isReversed ? 'reversed' : 'upright'}`}>
+              {cardModal.isReversed ? ui.reversed : ui.upright}
+            </span>
+            <p className="card-meaning-text">{getMeaning(cardModal.card, lang, cardModal.isReversed)}</p>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Spreads.jsx
+++ b/src/pages/Spreads.jsx
@@ -21,7 +21,6 @@ export default function Spreads() {
   const [notebookEntries, setNotebookEntries] = useState([]);
   const [focusedSlotIndex, setFocusedSlotIndex] = useState(null);
   const [showSummary,     setShowSummary]     = useState(false);
-  const [cardModal,       setCardModal]       = useState(null);
 
   function handleSpreadSelect(spreadId) {
     setPendingSpread(SPREADS[spreadId]);
@@ -38,7 +37,6 @@ export default function Spreads() {
     setNotebookEntries([]);
     setFocusedSlotIndex(null);
     setShowSummary(false);
-    setCardModal(null);
     setPhase('reading');
   }
 
@@ -46,9 +44,6 @@ export default function Spreads() {
     const entry = drawnCards[index];
     if (!entry) return;
     if (entry.isFlipped) {
-      const pos = selectedSpread.positions[index];
-      const notebookEntry = notebookEntries.find(e => e.positionIndex === index);
-      setCardModal(notebookEntry ?? { card: entry.card, isReversed: entry.isReversed, pos, positionIndex: index });
       setFocusedSlotIndex(index);
       return;
     }
@@ -70,7 +65,6 @@ export default function Spreads() {
     setIntention('');
     setPendingSpread(null);
     setShowSummary(false);
-    setCardModal(null);
   }
 
   // ── Selector ─────────────────────────────────────────────────────────────────
@@ -251,34 +245,7 @@ export default function Spreads() {
         </div>
       </div>
 
-      {cardModal && (
-        <div
-          className="card-meaning-overlay"
-          onClick={() => setCardModal(null)}
-          role="dialog"
-          aria-modal="true"
-          aria-label={getCardName(cardModal.card, lang)}
-        >
-          <div className="card-meaning-modal" onClick={e => e.stopPropagation()}>
-            <button
-              className="card-meaning-close"
-              onClick={() => setCardModal(null)}
-              aria-label={ui.closeModal}
-            >
-              ×
-            </button>
-            <div className="card-meaning-pos">{getPositionLabel(cardModal.pos, lang)}</div>
-            {getPositionDescription(cardModal.pos, lang) && (
-              <p className="card-meaning-pos-desc">{getPositionDescription(cardModal.pos, lang)}</p>
-            )}
-            <h3 className="card-meaning-name">{getCardName(cardModal.card, lang)}</h3>
-            <span className={`orientation-badge ${cardModal.isReversed ? 'reversed' : 'upright'}`}>
-              {cardModal.isReversed ? ui.reversed : ui.upright}
-            </span>
-            <p className="card-meaning-text">{getMeaning(cardModal.card, lang, cardModal.isReversed)}</p>
-          </div>
-        </div>
-      )}
+
     </div>
   );
 }


### PR DESCRIPTION
Clicking a revealed card in a spread now opens a modal showing the card name, orientation (upright/reversed), and full interpretation. Works for all spread types and respects the current language (ES/EN/FR).

Closes #9
